### PR TITLE
Fixed bug in public T GetFirstComponentOfTypeOfEntity<T>(int entityID…

### DIFF
--- a/ECS/Context.cs
+++ b/ECS/Context.cs
@@ -446,7 +446,7 @@ public sealed class Context
 
         if( cachedComponentsByEntity.TryGetValue(entityID, out components) )
         {
-            foreach( var c in cachedComponentsByEntity )
+            foreach( var c in components )
             {
                 var cAsT = c as T;
 


### PR DESCRIPTION
Fixed bug in public T GetFirstComponentOfTypeOfEntity<T>(int entityID…) that caused the method to always return null